### PR TITLE
nomulishサーバーの変更に追随

### DIFF
--- a/src/scripts/nomulish.coffee
+++ b/src/scripts/nomulish.coffee
@@ -29,7 +29,8 @@ module.exports = (robot) ->
         form:
           before: words
           level: level
-          trans_btn: true # 何でもよいので値を入れる
+          options: 'nochk'
+          transbtn: true # 何でもよいので値を入れる
         , (e, _, body) ->
           if e?
             robot.logger.error e.message
@@ -37,5 +38,5 @@ module.exports = (robot) ->
             return
 
           $ = cheerio.load body
-          nomulish = $('textarea[name=after]').val()
+          nomulish = $('textarea[name=after1]').val()
           res.send nomulish


### PR DESCRIPTION
サーバーの変更に追随しました。
オプションが（おそらく）増えていたので、とりあえず`nochk`を選ぶようにしました。

- `nochk`
  - 普通に翻訳
- `p0chk`
  - 登録単語のみで翻訳
- `p100chk`
  - 自動補完のみで翻訳
